### PR TITLE
Remove trailing double quote from $item->onclick2

### DIFF
--- a/admin/libraries/phocagallery/image/imagefront.php
+++ b/admin/libraries/phocagallery/image/imagefront.php
@@ -1101,7 +1101,7 @@ class PhocaGalleryImageFront
 			$item->linkorig		= $imgLinkOrig;
 			$item->onclick		= '';
 			$item->itemprop		= 'contentUrl';
-			$item->onclick2		= 'document.getElementById(\'pgImg'.$item->id.'\').click();"';
+			$item->onclick2		= 'document.getElementById(\'pgImg'.$item->id.'\').click();';
 			$item->onclick3		= $item->onclick;
 
 


### PR DESCRIPTION
- I installed J4 nightly.
- I installed com_phocagallery_v4.5.0Alpha1.zip from https://www.phoca.cz/download/category/1-phoca-gallery-component
- Changed nothing in settings.
- Created a category.
- added some images
- created menu item of type "List of Images (Category View)"
- checked source code of menu item in front-end.

#### Before applying patch
- 2 quotes after onclick parameter (see image, gray arrow)

![24-06-_2021_17-40-03](https://user-images.githubusercontent.com/20780646/123294059-cc627980-d514-11eb-9f38-a0d21bed602a.jpg)

#### After 
- 1 quote after onclick parameter (see image, gray arrow)

![24-06-_2021_17-53-06](https://user-images.githubusercontent.com/20780646/123294523-39760f00-d515-11eb-9a7e-a85a622280b7.jpg)

#### Additional
I think line 1090 should be changed accordingly but I haven't tested it. Therefore I didn't adapt it with this pr:
1090: `$item->onclick2		= 'document.getElementById(\'pgImg'.$item->id.'\').click();"';`